### PR TITLE
カテゴリ設定をスプレッドシート上からできるようにする

### DIFF
--- a/src/base_classes/base_sheet_data.js
+++ b/src/base_classes/base_sheet_data.js
@@ -81,29 +81,3 @@ export class BoundSheetData extends BaseSheetData {
     return this._SSID;
   }
 }
-
-/**
- * `BaseSheetData` クラスを継承し、EDIデータ変換ツール_マスターデータのデータ操作を提供するクラス。
- */
-export class MasterSheetData extends BaseSheetData {
-  /**
-   * EDIデータ変換ツール_マスターデータのスプレッドシートIDを返します。
-   * @return {string} スプレッドシートID
-   */
-  static get SSID() {
-    return '1LQohbUMHNFajVhcF5izRtIVmGraQqQWbglw5Ph-wLAU';
-  }
-}
-
-/**
- * `BaseSheetData` クラスを継承し、LTエラー例外受注一覧のデータ操作を提供するクラス。
- */
-export class LtErrorExceptionApprovedOrdersSheetData extends BaseSheetData {
-  /**
-   * LTエラー例外受注一覧のスプレッドシートIDを返します。
-   * @return {string} スプレッドシートID
-   */
-  static get SSID() {
-    return '1-vF6vNEfAYb4yH98mvnDPxL8q8g4LVFOLw5H69sbYK0';
-  }
-}

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,10 +1,16 @@
 export const BOUND_SHEETS = {
   DATA: 'data',
   CONFIG: 'config',
+  CATEGORIES: 'categories',
 };
 
 export const NAMED_RANGES = {
-  BOUND_SHEETS: {},
+  BOUND_SHEETS: {
+    CATEGORIES: {
+      CATEGORY: 'CATEGORIES.CATEGORY',
+      COLOR: 'CATEGORIES.COLOR',
+    }
+  },
 };
 
 export const METHODS = {

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import { AddTabFunctionsOperation } from "operations/add_tab_functions_operation
 import { ShowChartModalOperation } from "operations/show_chart_modal_operation";
 import { GetSheetDataOperation } from "operations/get_sheet_data_operation";
 import { GetConfigOperation } from "operations/get_config_operation";
+import { GetCategoryColorsOperation } from "operations/get_category_colors_operation";
 
 global.TEST = () => {
   const operation = new TestOperation();
@@ -27,8 +28,10 @@ global.showChartModalOperation = () => {
 global.getChartInitialDataOperation = () => {
   const sheetData = new GetSheetDataOperation().run();
   const configData = new GetConfigOperation().run();
+  const categoryColors = new GetCategoryColorsOperation().run();
   return {
     sheetData: sheetData,
     config: configData,
+    categoryColors: categoryColors,
   };
 };

--- a/src/operations/get_category_colors_operation.js
+++ b/src/operations/get_category_colors_operation.js
@@ -1,0 +1,22 @@
+// src/operations/get_category_colors_operation.js
+
+import { BaseOperation } from 'base_classes/base_operation';
+import { Categories } from 'sheet_data/categories'; // 新しくimport
+
+/**
+ * 'categories'シートからカテゴリと色の対応を取得するオペレーション。
+ * @returns {Object.<string, string>} カテゴリ名をキー、カラーコードを値とするオブジェクト。
+ */
+export class GetCategoryColorsOperation extends BaseOperation {
+  constructor() {
+    super();
+  }
+
+  /**
+   * @override
+   */
+  _operation() {
+    // Categoriesクラス経由でデータを取得するように変更
+    return Categories.colors;
+  }
+}

--- a/src/sheet_data/categories.js
+++ b/src/sheet_data/categories.js
@@ -1,0 +1,43 @@
+import { BoundSheetData } from 'base_classes/base_sheet_data';
+import { BOUND_SHEETS, NAMED_RANGES } from 'constants';
+
+/**
+ * 'categories'シートへのデータアクセスを提供するクラス。
+ */
+export class Categories extends BoundSheetData {
+  /**
+   * キャッシュされたカテゴリと色の生の対応データを配列として返します。
+   * @returns {Array<Object>} {index: number, category: string, color: string} のフリーズされたオブジェクトの配列。
+   */
+  static get all() {
+    const get = () => {
+      const data = this._getSheet(BOUND_SHEETS.CATEGORIES).getDataRange().getValues().slice(1).filter(row => row[0]);
+      const namedRangeCols = this._getNamedRangeColsOf(this._getSheet(BOUND_SHEETS.CATEGORIES));
+
+      return data.map((row, index) => {
+        return Object.freeze({
+          index: index,
+          category: row[namedRangeCols[NAMED_RANGES.BOUND_SHEETS.CATEGORIES.CATEGORY] - 1].trim(),
+          color: row[namedRangeCols[NAMED_RANGES.BOUND_SHEETS.CATEGORIES.COLOR] - 1].trim(),
+        });
+      });
+    };
+    this._allCache = this._allCache || get();
+    return this._allCache;
+  }
+
+  /**
+   * カテゴリをキー、カラーコードを値とするオブジェクトを返します。
+   * @returns {Object.<string, string>}
+   */
+  static get colors() {
+    const get = () => {
+      return this.all.reduce((acc, item) => {
+        acc[item.category] = item.color;
+        return acc;
+      }, {});
+    };
+    this._colorsCache = this._colorsCache || get();
+    return this._colorsCache;
+  }
+}

--- a/src/ui/chart_racer.js
+++ b/src/ui/chart_racer.js
@@ -1,9 +1,10 @@
-import { categoryColors } from 'ui/config.js';
-
 export class ChartRacer {
-  constructor(config, data) {
+  // コンストラクタで categoryColors を受け取る
+  constructor(config, data, categoryColors) {
     this.config = config;
     this.data = data;
+    this.categoryColors = categoryColors; // プロパティとして保持
+    this.defaultColor = '#CCCCCC';      // デフォルト色を定義
     this.chart = null;
     this.stopped = true;
     this.timer = null;
@@ -57,7 +58,7 @@ export class ChartRacer {
       position: 'inside top right',
       layout: 'vertical',
       margin_top: 50,
-      customEntries: Object.keys(categoryColors).map(key => ({ name: key, icon: { color: categoryColors[key] } }))
+      customEntries: Object.keys(this.categoryColors).map(key => ({ name: key, icon: { color: this.categoryColors[key] } }))
     };
   }
 
@@ -109,7 +110,7 @@ export class ChartRacer {
         x: index,
         id: item.item,
         y: item[dateStr],
-        color: categoryColors[item.category]
+        color: this.categoryColors[item.category] || this.defaultColor
       }))
     }];
   }

--- a/src/ui/config.js
+++ b/src/ui/config.js
@@ -1,8 +1,0 @@
-// カテゴリー別の色設定（BASE FOOD商品用）
-export const categoryColors = {
-  'BASE BREAD': '#ff6b6b',      // 赤系
-  'BASE Cookies': '#4ecdc4',     // 青緑系
-  'BASE PASTA': '#ffe66d',       // 黄色系
-  'BASE YAKISOBA': '#ff9f43',    // オレンジ系
-  'Others': '#95a5a6'            // グレー系
-};

--- a/src/ui/data_utils.js
+++ b/src/ui/data_utils.js
@@ -57,7 +57,7 @@ export async function getChartInitialData() {
 
 /**
  * サーバーからデータを取得し、クライアントサイドで利用可能な形式に整形する
- * @returns {Promise<{config: object, data: Array<Object>}>}
+ * @returns {Promise<{config: object, data: Array<Object>, categoryColors: object}>}
  */
 export async function fetchAndParseChartData() {
   const initialData = await getChartInitialData();
@@ -71,5 +71,6 @@ export async function fetchAndParseChartData() {
   return {
     config: initialData.config,
     data: data,
+    categoryColors: initialData.categoryColors,
   };
 }

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -3,8 +3,8 @@ import { fetchAndParseChartData } from './data_utils.js';
 
 window.addEventListener('load', async () => {
   try {
-    const { config, data } = await fetchAndParseChartData();
-    new ChartRacer(config, data).init();
+    const { config, data, categoryColors } = await fetchAndParseChartData();
+    new ChartRacer(config, data, categoryColors).init();
   } catch (error) {
     console.error("Chart initialization failed:", error);
   }


### PR DESCRIPTION
- 'categories'シートからカテゴリ色を動的に読み込む機能を追加。
- にカテゴリ色取得処理を統合し、サーバー呼び出しを一本化。
- 'categories'シートのデータアクセスをを継承した新しいクラスにリファクタリング。
- クラスで名前付き範囲（, ）を利用し、堅牢な列識別を実現。
- ハードコードされていたのを削除し、ファイルも削除。